### PR TITLE
Configure React App to match infotainment mockup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "UI-infotainment",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "private": true,
     "dependencies": {
         "@ionic/react": "^5.5.0",

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Ionic App</title>
+    <title>Relectric Infotainment UI</title>
 
     <base href="/" />
 
@@ -20,7 +20,7 @@
 
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-title" content="Ionic App" />
+    <meta name="apple-mobile-web-app-title" content="Relectric Infotainment UI" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
   </head>
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,21 +1,21 @@
 {
-  "short_name": "Ionic App",
-  "name": "My Ionic App",
-  "icons": [
-    {
-      "src": "assets/icon/favicon.png",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "assets/icon/icon.png",
-      "type": "image/png",
-      "sizes": "512x512",
-      "purpose": "maskable"
-    }
-  ],
-  "start_url": ".",
-  "display": "standalone",
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff"
+    "short_name": "Relectric Infotainment UI",
+    "name": "Relectric Infotainment UI",
+    "icons": [
+        {
+            "src": "assets/icon/favicon.png",
+            "sizes": "64x64 32x32 24x24 16x16",
+            "type": "image/x-icon"
+        },
+        {
+            "src": "assets/icon/icon.png",
+            "type": "image/png",
+            "sizes": "512x512",
+            "purpose": "maskable"
+        }
+    ],
+    "start_url": ".",
+    "display": "standalone",
+    "theme_color": "#ffffff",
+    "background_color": "#ffffff"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,37 +26,21 @@ import '@ionic/react/css/display.css';
 
 /* Theme variables */
 import './theme/variables.css';
+import TabBar from './components/TabBar';
+import Home from './pages/Home';
 
 const App: React.FC = () => (
     <IonApp>
         <IonReactRouter>
-            <IonTabs>
-                <IonRouterOutlet>
-                    <Route path="/navigation" component={Navigation} exact={true} />
-                    <Route path="/car" component={Car} exact={true} />
-                    <Route path="/music" component={Music} exact={true} />
-                    <Route path="/settings" component={Settings} />
-                    <Route path="/" render={() => <Redirect to="/navigation" />} exact={true} />
-                </IonRouterOutlet>
-                <IonTabBar slot="bottom">
-                    <IonTabButton tab="navigation" href="/navigation">
-                        <IonIcon icon={navigateOutline} />
-                        <IonLabel>Navigation</IonLabel>
-                    </IonTabButton>
-                    <IonTabButton tab="car" href="/car">
-                        <IonIcon icon={carOutline} />
-                        <IonLabel>Car</IonLabel>
-                    </IonTabButton>
-                    <IonTabButton tab="music" href="/music">
-                        <IonIcon icon={musicalNoteOutline} />
-                        <IonLabel>Music</IonLabel>
-                    </IonTabButton>
-                    <IonTabButton tab="settings" href="/settings">
-                        <IonIcon icon={menuOutline} />
-                        <IonLabel>Settings</IonLabel>
-                    </IonTabButton>
-                </IonTabBar>
-            </IonTabs>
+            <IonRouterOutlet>
+                <Route path="/navigation" component={Navigation} exact={true} />
+                <Route path="/home" component={Home} exact={true} />
+                <Route path="/car" component={Car} exact={true} />
+                <Route path="/music" component={Music} exact={true} />
+                <Route path="/settings" component={Settings} />
+                <Route path="/" render={() => <Redirect to="/home" />} exact={true} />
+            </IonRouterOutlet>
+            <TabBar />
         </IonReactRouter>
     </IonApp>
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import { Redirect, Route } from 'react-router-dom';
-import { IonApp, IonIcon, IonLabel, IonRouterOutlet, IonTabBar, IonTabButton, IonTabs } from '@ionic/react';
-import { IonReactRouter } from '@ionic/react-router';
-import { carOutline, musicalNoteOutline, navigateOutline, menuOutline } from 'ionicons/icons';
-import Navigation from './pages/Navigation';
-import Car from './pages/Car';
-import Music from './pages/Music';
-import Settings from './pages/Settings';
+import { IonApp } from '@ionic/react';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -26,22 +19,11 @@ import '@ionic/react/css/display.css';
 
 /* Theme variables */
 import './theme/variables.css';
-import TabBar from './components/TabBar';
-import Home from './pages/Home';
+import AppContainer from './pages/AppContainer';
 
 const App: React.FC = () => (
     <IonApp>
-        <IonReactRouter>
-            <IonRouterOutlet>
-                <Route path="/navigation" component={Navigation} exact={true} />
-                <Route path="/home" component={Home} exact={true} />
-                <Route path="/car" component={Car} exact={true} />
-                <Route path="/music" component={Music} exact={true} />
-                <Route path="/settings" component={Settings} />
-                <Route path="/" render={() => <Redirect to="/home" />} exact={true} />
-            </IonRouterOutlet>
-            <TabBar />
-        </IonReactRouter>
+        <AppContainer />
     </IonApp>
 );
 

--- a/src/Models/Enums.ts
+++ b/src/Models/Enums.ts
@@ -1,0 +1,22 @@
+/**
+ * Enums.ts
+ *
+ * This file is used to to store enumerations to be used for type checking across various components
+ */
+
+/**
+ * Enum: Pages
+ *
+ * Used for type-strict enforcement of pages
+ *
+ * @author Ratik Kapoor
+ * @since 0.0.2
+ */
+export enum Pages {
+    Home = 'Home',
+    Car = 'Car',
+    Climate = 'Climate',
+    Music = 'Music',
+    Navigation = 'Navigation',
+    Settings = 'Settings',
+}

--- a/src/components/TabBar.css
+++ b/src/components/TabBar.css
@@ -1,0 +1,10 @@
+.TabBarRow {
+    justify-content: space-around;
+}
+.IonColMiddle {
+    text-align: center;
+}
+
+.IonColRight {
+    text-align: right;
+}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,26 +1,75 @@
-import { IonIcon, IonLabel, IonTabBar, IonTabButton } from '@ionic/react';
-import { carOutline, menuOutline, musicalNoteOutline, navigateOutline } from 'ionicons/icons';
+import { IonButton, IonCol, IonFooter, IonGrid, IonIcon, IonRow } from '@ionic/react';
+import {
+    carOutline,
+    menuOutline,
+    musicalNoteOutline,
+    navigateOutline,
+    volumeHighOutline,
+    thermometerOutline,
+} from 'ionicons/icons';
 import React from 'react';
+import { Pages } from '../Models/Enums';
+import './TabBar.css';
 
-const TabBar: React.FC = () => (
-    <IonTabBar slot="bottom">
-        <IonTabButton tab="navigation" href="/navigation">
-            <IonIcon icon={navigateOutline} />
-            <IonLabel>Navigation</IonLabel>
-        </IonTabButton>
-        <IonTabButton tab="car" href="/car">
-            <IonIcon icon={carOutline} />
-            <IonLabel>Car</IonLabel>
-        </IonTabButton>
-        <IonTabButton tab="music" href="/music">
-            <IonIcon icon={musicalNoteOutline} />
-            <IonLabel>Music</IonLabel>
-        </IonTabButton>
-        <IonTabButton tab="settings" href="/settings">
-            <IonIcon icon={menuOutline} />
-            <IonLabel>Settings</IonLabel>
-        </IonTabButton>
-    </IonTabBar>
+interface TabBarProps {
+    pageCallback: CallableFunction;
+}
+
+const TabBar: React.FC<TabBarProps> = (props: TabBarProps) => (
+    <IonFooter>
+        <IonGrid>
+            <IonRow className="TabBarRow">
+                <IonCol>
+                    <IonButton fill="clear" size="large" shape="round">
+                        <IonIcon icon={volumeHighOutline} />
+                    </IonButton>
+                </IonCol>
+                <IonCol className="IonColMiddle">
+                    <IonButton
+                        onClick={() => props.pageCallback(Pages.Navigation)}
+                        fill="clear"
+                        size="large"
+                        color="medium"
+                        shape="round"
+                    >
+                        <IonIcon icon={navigateOutline} />
+                    </IonButton>
+                    <IonButton
+                        onClick={() => props.pageCallback(Pages.Car)}
+                        fill="clear"
+                        size="large"
+                        color="medium"
+                        shape="round"
+                    >
+                        <IonIcon icon={carOutline} />
+                    </IonButton>
+                    <IonButton
+                        onClick={() => props.pageCallback(Pages.Music)}
+                        fill="clear"
+                        size="large"
+                        color="medium"
+                        shape="round"
+                    >
+                        <IonIcon icon={musicalNoteOutline} />
+                    </IonButton>
+                    <IonButton
+                        onClick={() => props.pageCallback(Pages.Settings)}
+                        fill="clear"
+                        size="large"
+                        color="medium"
+                        shape="round"
+                    >
+                        <IonIcon icon={menuOutline} />
+                    </IonButton>
+                </IonCol>
+                <IonCol className="IonColRight">
+                    <IonButton fill="clear" size="large" shape="round">
+                        <IonIcon icon={thermometerOutline} />
+                    </IonButton>
+                </IonCol>
+            </IonRow>
+        </IonGrid>
+    </IonFooter>
 );
 
 export default TabBar;

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,0 +1,26 @@
+import { IonIcon, IonLabel, IonTabBar, IonTabButton } from '@ionic/react';
+import { carOutline, menuOutline, musicalNoteOutline, navigateOutline } from 'ionicons/icons';
+import React from 'react';
+
+const TabBar: React.FC = () => (
+    <IonTabBar slot="bottom">
+        <IonTabButton tab="navigation" href="/navigation">
+            <IonIcon icon={navigateOutline} />
+            <IonLabel>Navigation</IonLabel>
+        </IonTabButton>
+        <IonTabButton tab="car" href="/car">
+            <IonIcon icon={carOutline} />
+            <IonLabel>Car</IonLabel>
+        </IonTabButton>
+        <IonTabButton tab="music" href="/music">
+            <IonIcon icon={musicalNoteOutline} />
+            <IonLabel>Music</IonLabel>
+        </IonTabButton>
+        <IonTabButton tab="settings" href="/settings">
+            <IonIcon icon={menuOutline} />
+            <IonLabel>Settings</IonLabel>
+        </IonTabButton>
+    </IonTabBar>
+);
+
+export default TabBar;

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -19,7 +19,7 @@ const TabBar: React.FC<TabBarProps> = (props: TabBarProps) => (
     <IonFooter>
         <IonGrid>
             <IonRow className="TabBarRow">
-                <IonCol>
+                <IonCol size="2">
                     <IonButton fill="clear" size="large" shape="round">
                         <IonIcon icon={volumeHighOutline} />
                     </IonButton>
@@ -62,7 +62,7 @@ const TabBar: React.FC<TabBarProps> = (props: TabBarProps) => (
                         <IonIcon icon={menuOutline} />
                     </IonButton>
                 </IonCol>
-                <IonCol className="IonColRight">
+                <IonCol className="IonColRight" size="2">
                     <IonButton fill="clear" size="large" shape="round">
                         <IonIcon icon={thermometerOutline} />
                     </IonButton>

--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import Home from './Home';
+import TabBar from '../components/TabBar';
+import { Pages } from '../Models/Enums';
+import ComponentModal from './ComponentModal';
+
+const AppContainer: React.FC = () => {
+    const [currentPage, setCurrentPage] = useState<Pages>(Pages.Home);
+
+    const setPage = (page: Pages) => {
+        console.log(page);
+        setCurrentPage(page);
+    };
+
+    return (
+        <>
+            <ComponentModal page={currentPage} pageCallback={setPage} />
+            <Home />
+            <TabBar pageCallback={setPage} />
+        </>
+    );
+};
+
+export default AppContainer;

--- a/src/pages/Car.tsx
+++ b/src/pages/Car.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 import ExploreContainer from '../components/ExploreContainer';
 
-const Tab2: React.FC = () => {
+const Car: React.FC = () => {
     return (
         <IonPage>
             <IonHeader>
@@ -22,4 +22,4 @@ const Tab2: React.FC = () => {
     );
 };
 
-export default Tab2;
+export default Car;

--- a/src/pages/Climate.tsx
+++ b/src/pages/Climate.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import ExploreContainer from '../components/ExploreContainer';
+
+const Climate: React.FC = () => {
+    return (
+        <IonPage>
+            <IonHeader>
+                <IonToolbar>
+                    <IonTitle>Climate</IonTitle>
+                </IonToolbar>
+            </IonHeader>
+            <IonContent fullscreen>
+                <IonHeader collapse="condense">
+                    <IonToolbar>
+                        <IonTitle size="large">Climate</IonTitle>
+                    </IonToolbar>
+                </IonHeader>
+                <ExploreContainer name="Climate" />
+            </IonContent>
+        </IonPage>
+    );
+};
+
+export default Climate;

--- a/src/pages/ComponentModal.css
+++ b/src/pages/ComponentModal.css
@@ -1,0 +1,4 @@
+.ComponentModal .modal-wrapper {
+    min-width: 90%;
+    min-height: 80%;
+}

--- a/src/pages/ComponentModal.tsx
+++ b/src/pages/ComponentModal.tsx
@@ -1,16 +1,35 @@
 import React from 'react';
-import { IonButton, IonContent, IonModal, IonText } from '@ionic/react';
-import { useState } from 'react';
+import { IonContent, IonModal } from '@ionic/react';
+import { Pages } from '../Models/Enums';
+import Music from './Music';
+import Car from './Car';
+import Climate from './Climate';
+import Navigation from './Navigation';
+import Settings from './Settings';
+import './ComponentModal.css';
 
-const ComponentModal: React.FC = () => {
-    const [showModal, setShowModal] = useState(false);
+interface ComponentModalProps {
+    page: Pages;
+    pageCallback: CallableFunction;
+}
 
+const ComponentModal: React.FC<ComponentModalProps> = (props: ComponentModalProps) => {
     return (
         <IonContent>
-            <IonModal isOpen={showModal}>
-                <IonText>Blah</IonText>
+            <IonModal
+                isOpen={props.page === Pages.Home ? false : true}
+                onDidDismiss={() => {
+                    props.pageCallback(Pages.Home);
+                }}
+                swipeToClose={true}
+                cssClass="ComponentModal"
+            >
+                {props.page == Pages.Music && <Music />}
+                {props.page == Pages.Car && <Car />}
+                {props.page == Pages.Climate && <Climate />}
+                {props.page == Pages.Navigation && <Navigation />}
+                {props.page == Pages.Settings && <Settings />}
             </IonModal>
-            <IonButton onClick={(e) => setShowModal(true)} />
         </IonContent>
     );
 };

--- a/src/pages/ComponentModal.tsx
+++ b/src/pages/ComponentModal.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { IonButton, IonContent, IonModal, IonText } from '@ionic/react';
+import { useState } from 'react';
+
+const ComponentModal: React.FC = () => {
+    const [showModal, setShowModal] = useState(false);
+
+    return (
+        <IonContent>
+            <IonModal isOpen={showModal}>
+                <IonText>Blah</IonText>
+            </IonModal>
+            <IonButton onClick={(e) => setShowModal(true)} />
+        </IonContent>
+    );
+};
+
+export default ComponentModal;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 import ExploreContainer from '../components/ExploreContainer';
-import ComponentModal from './ComponentModal';
 
 const Home: React.FC = () => {
     return (
@@ -19,7 +18,6 @@ const Home: React.FC = () => {
                     </IonToolbar>
                 </IonHeader>
                 <ExploreContainer name="Home" />
-                <ComponentModal />
             </IonContent>
         </IonPage>
     );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import ExploreContainer from '../components/ExploreContainer';
+import ComponentModal from './ComponentModal';
+
+const Home: React.FC = () => {
+    return (
+        <IonPage>
+            <IonHeader>
+                <IonToolbar>
+                    <IonTitle>Home</IonTitle>
+                </IonToolbar>
+            </IonHeader>
+            <IonContent fullscreen>
+                <IonHeader collapse="condense">
+                    <IonToolbar>
+                        <IonTitle size="large">Home</IonTitle>
+                        {/* TODO: Add time here */}
+                    </IonToolbar>
+                </IonHeader>
+                <ExploreContainer name="Home" />
+                <ComponentModal />
+            </IonContent>
+        </IonPage>
+    );
+};
+
+export default Home;

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 import ExploreContainer from '../components/ExploreContainer';
 
-const Tab3: React.FC = () => {
+const Music: React.FC = () => {
     return (
         <IonPage>
             <IonHeader>
                 <IonToolbar>
-                    <IonTitle>Tab 3</IonTitle>
+                    <IonTitle>Music</IonTitle>
                 </IonToolbar>
             </IonHeader>
             <IonContent fullscreen>
                 <IonHeader collapse="condense">
                     <IonToolbar>
-                        <IonTitle size="large">Tab 3</IonTitle>
+                        <IonTitle size="large">Music</IonTitle>
                     </IonToolbar>
                 </IonHeader>
                 <ExploreContainer name="Music Page" />
@@ -22,4 +22,4 @@ const Tab3: React.FC = () => {
     );
 };
 
-export default Tab3;
+export default Music;

--- a/src/pages/Navigation.tsx
+++ b/src/pages/Navigation.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 import ExploreContainer from '../components/ExploreContainer';
 
-const Tab1: React.FC = () => {
+const Navigation: React.FC = () => {
     return (
         <IonPage>
             <IonHeader>
                 <IonToolbar>
-                    <IonTitle>Tab 1</IonTitle>
+                    <IonTitle>Navigation</IonTitle>
                 </IonToolbar>
             </IonHeader>
             <IonContent fullscreen>
                 <IonHeader collapse="condense">
                     <IonToolbar>
-                        <IonTitle size="large">Tab 1 Dhyey says hello</IonTitle>
+                        <IonTitle size="large">Navigation</IonTitle>
                     </IonToolbar>
                 </IonHeader>
                 <ExploreContainer name="Navigation Page" />
@@ -22,4 +22,4 @@ const Tab1: React.FC = () => {
     );
 };
 
-export default Tab1;
+export default Navigation;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 import ExploreContainer from '../components/ExploreContainer';
 
-const Tab4: React.FC = () => {
+const Settings: React.FC = () => {
     return (
         <IonPage>
             <IonHeader>
                 <IonToolbar>
-                    <IonTitle>Tab 4</IonTitle>
+                    <IonTitle>Settings</IonTitle>
                 </IonToolbar>
             </IonHeader>
             <IonContent fullscreen>
                 <IonHeader collapse="condense">
                     <IonToolbar>
-                        <IonTitle size="large">Tab 1 Dhyey says hello</IonTitle>
+                        <IonTitle size="large">Settings</IonTitle>
                     </IonToolbar>
                 </IonHeader>
                 <ExploreContainer name="Settings Page" />
@@ -22,4 +22,4 @@ const Tab4: React.FC = () => {
     );
 };
 
-export default Tab4;
+export default Settings;


### PR DESCRIPTION
Added components to match implementation goals of infotainment mockup.

Changelog:
- Created `Enums.ts` containing page names for all pages
- Renamed components ex: `Tab1` to `Navigation`
- Renamed `Ionic App` to `Relectric Infotainment UI`
- Created `AppContainer.tsx` to hold nav and home back-layer
- Created `TabBar.tsx` with three sub-sections
- Created `ComponentModal.tsx` following infotainment mockup
- Implemented callback functions for showing different screens, passed through props