### PR TITLE
feat: Bottom tab bar floating above Modal

### DIFF
--- a/src/components/TabBar.css
+++ b/src/components/TabBar.css
@@ -8,3 +8,7 @@
 .IonColRight {
     text-align: right;
 }
+
+.TabBar {
+    z-index: 999999;
+}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -16,7 +16,7 @@ interface TabBarProps {
 }
 
 const TabBar: React.FC<TabBarProps> = (props: TabBarProps) => (
-    <IonFooter>
+    <IonFooter className="TabBar">
         <IonGrid>
             <IonRow className="TabBarRow">
                 <IonCol size="2">


### PR DESCRIPTION
The bottom nav bar now can be clicked even when a modal is open.

Potential Issues:
- Is a user clicks/taps the bottom bar more than 180,000 times the Modal would take priority over the TabBar

Changelog:
- Added `className` to `IonFooter` for NavBar.tsx
- Added a big z-index to styling of `IonFooter`