### PR TITLE
Feat/brooke/homepage

### DIFF
--- a/src/pages/ComponentModal.css
+++ b/src/pages/ComponentModal.css
@@ -5,7 +5,7 @@
 
 .time {
     font-size: 58px;
-    color: #8c8c8c;
+    color: #565656;
     line-height: 26px;
     text-align: center;
     position: absolute;
@@ -13,4 +13,15 @@
     right: 0;
     top: 50%;
     transform: translateY(-50%);
+}
+
+.date {
+    font-size: 28px;
+    color: #787878;
+    text-align: center;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    transform: translateY(+100%);
 }

--- a/src/pages/ComponentModal.css
+++ b/src/pages/ComponentModal.css
@@ -2,3 +2,15 @@
     min-width: 90%;
     min-height: 80%;
 }
+
+.time {
+    font-size: 58px;
+    color: #8c8c8c;
+    line-height: 26px;
+    text-align: center;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,33 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
-import ExploreContainer from '../components/ExploreContainer';
+import './ComponentModal.css';
+
+function formatTime(originalTime: string) {
+    let updateTime = originalTime;
+
+    if (parseInt(originalTime.substring(0, 2)) > 12) {
+        const oldHour = parseInt(originalTime.substring(0, 2));
+        const newHour = oldHour - 12;
+
+        updateTime = originalTime.replace(oldHour.toString(), newHour.toString());
+    }
+
+    return updateTime;
+}
+
+function getTime() {
+    const [currentTime, setTime] = useState(formatTime(new Date().toLocaleTimeString()));
+
+    useEffect(() => {
+        const secTimer = setInterval(() => {
+            setTime(formatTime(new Date().toLocaleTimeString()));
+        }, 1000);
+
+        return () => clearInterval(secTimer);
+    }, []);
+
+    return currentTime;
+}
 
 const Home: React.FC = () => {
     return (
@@ -17,7 +44,7 @@ const Home: React.FC = () => {
                         {/* TODO: Add time here */}
                     </IonToolbar>
                 </IonHeader>
-                <ExploreContainer name="Home" />
+                <div className="time">{getTime()}</div>
             </IonContent>
         </IonPage>
     );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,7 +4,6 @@ import './ComponentModal.css';
 
 function formatTime(originalTime: string) {
     let updateTime = originalTime;
-
     if (parseInt(originalTime.substring(0, 2)) > 12) {
         const oldHour = parseInt(originalTime.substring(0, 2));
         const newHour = oldHour - 12;
@@ -15,18 +14,80 @@ function formatTime(originalTime: string) {
     return updateTime;
 }
 
-function getTime() {
+function formatDate(originalDate: string) {
+    let updateMonth = 'Error';
+    let updateDate = 'Error';
+    let updateYear = 'Error';
+    // eslint-disable-next-line prettier/prettier
+    const regexSearch = /([0-9]+)([0-9]+)([0-9]+)/;
+    const searchResult = originalDate.match(regexSearch);
+    if (searchResult != null) {
+        updateMonth = searchResult[2];
+        updateDate = searchResult[1];
+        updateYear = searchResult[0];
+    }
+
+    switch (parseInt(updateMonth)) {
+        case 1:
+            updateMonth = 'January';
+            break;
+        case 2:
+            updateMonth = 'February';
+            break;
+        case 3:
+            updateMonth = 'March';
+            break;
+        case 4:
+            updateMonth = 'April';
+            break;
+        case 5:
+            updateMonth = 'May';
+            break;
+        case 6:
+            updateMonth = 'June';
+            break;
+        case 7:
+            updateMonth = 'July';
+            break;
+        case 8:
+            updateMonth = 'August';
+            break;
+        case 9:
+            updateMonth = 'September';
+            break;
+        case 10:
+            updateMonth = 'October';
+            break;
+        case 11:
+            updateMonth = 'November';
+            break;
+        case 12:
+            updateMonth = 'December';
+            break;
+    }
+
+    const returnDate = updateMonth.concat(' ' + updateDate + ', ' + updateYear);
+    return returnDate;
+}
+
+function getDateTime() {
     const [currentTime, setTime] = useState(formatTime(new Date().toLocaleTimeString()));
+    const [currentDate, setDate] = useState(formatDate(new Date().toLocaleDateString()));
 
     useEffect(() => {
         const secTimer = setInterval(() => {
-            setTime(formatTime(new Date().toLocaleTimeString()));
+            setTime(formatTime(new Date().toLocaleTimeString())), setDate(formatDate(new Date().toLocaleDateString()));
         }, 1000);
 
         return () => clearInterval(secTimer);
     }, []);
 
-    return currentTime;
+    return (
+        <div>
+            <div className="time">{currentTime}</div>
+            <div className="date">{currentDate}</div>
+        </div>
+    );
 }
 
 const Home: React.FC = () => {
@@ -41,10 +102,9 @@ const Home: React.FC = () => {
                 <IonHeader collapse="condense">
                     <IonToolbar>
                         <IonTitle size="large">Home</IonTitle>
-                        {/* TODO: Add time here */}
                     </IonToolbar>
                 </IonHeader>
-                <div className="time">{getTime()}</div>
+                <div>{getDateTime()}</div>
             </IonContent>
         </IonPage>
     );


### PR DESCRIPTION
Updated the home page to have both the date and the time displayed on it. I corrected the time to only display in the format _hour:minute:second AM/PM_ in a theme-matching tone of gray. The date has also displays and has been modified to show up as _monthTitle dayValue, yearValue_, instead of in a digits-only format. 

Two new sections of _.time_ and _.date_ were added to the ComponentModal.css file to correctly format the date and time so they appear in the correct color, size, and location on the home page. These could be moved to their own CSS file if we'd like to keep them separate from the rest of the modal CSS. 

All the functions for date and time currently reside in Home.tsx, but could be moved to their own .txs file as they've made the home file pretty crowded and a bit difficult to navigate through, but for now it all works together. 