### PR TITLE
fix: Always use dark mode

### DIFF
--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -76,7 +76,7 @@ http://ionicframework.com/docs/theming/ */
     --ion-color-light-tint: #f5f6f9;
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light), (prefers-color-scheme: dark) {
     /*
    * Dark Colors
    * -------------------------------------------


### PR DESCRIPTION
Since no light mode interface is defined in the mockups, light mode should be disabled. Closes #34 

Changelog:
- Added "prefers light" to dark overrides in variables.css