### PR TITLE
Redux for the car

### DIFF
--- a/src/app/reducersindex.tsx
+++ b/src/app/reducersindex.tsx
@@ -68,3 +68,20 @@ export const doorStates = (
     rearPassengerDoorOpen: boolean;
     trunkOpen: boolean;
 } => state.carReducer.doorStates;
+
+export const tirePressure = (
+    state: RootState,
+): {
+    frontLeft: number;
+    frontRight: number;
+    backLeft: number;
+    backRight: number;
+} => state.carReducer.tirePressure;
+
+export const batteryLevel = (state: RootState): number[] => state.carReducer.batteryLevel;
+
+export const powerDraw = (state: RootState): number[] => state.carReducer.powerDraw;
+
+export const averagePowerDraw = (state: RootState): number => state.carReducer.averagePowerDraw;
+
+export const currentSpeed = (state: RootState): number => state.carReducer.currentSpeed;

--- a/src/app/reducersindex.tsx
+++ b/src/app/reducersindex.tsx
@@ -5,6 +5,7 @@ import batteryReducer, { BatteryStatus } from '../redux-features/Battery/Battery
 import bluetoothReducer from '../redux-features/Bluetooth/BluetoothStore';
 import darkModeReducer from '../redux-features/DarkMode/DarkModeStore';
 import notifReducer, { Notification } from '../components/Notification/NotificationStore';
+import carReducer from '../features/Car/CarStore';
 import { RootState } from './store';
 import { Pages } from '../Models/Enums';
 
@@ -23,6 +24,7 @@ export default combineReducers({
     batteryReducer,
     bluetoothReducer,
     notifReducer,
+    carReducer,
 });
 
 /**  Selectors for various redux states used throughout the UI.
@@ -56,3 +58,13 @@ export const isBatteryCharging = (state: RootState): boolean => state.batteryRed
 export const isBluetoothOn = (state: RootState): boolean => state.bluetoothReducer.bluetoothOn;
 
 export const notifications = (state: RootState): Array<Notification> => state.notifReducer.notifs;
+
+export const doorStates = (
+    state: RootState,
+): {
+    driverDoorOpen: boolean;
+    passengerDoorOpen: boolean;
+    rearDriverDoorOpen: boolean;
+    rearPassengerDoorOpen: boolean;
+    trunkOpen: boolean;
+} => state.carReducer.doorStates;

--- a/src/features/Car/CarStore.tsx
+++ b/src/features/Car/CarStore.tsx
@@ -66,8 +66,26 @@ export const slice = createSlice({
     initialState,
     reducers: {
         updateDoors: (state, action) => {
-            console.log(state);
-            console.log(action);
+            switch (action.payload.door) {
+                case 'driverDoor':
+                    state.doorStates.driverDoorOpen = action.payload.open;
+                    break;
+                case 'passengerDoor':
+                    state.doorStates.passengerDoorOpen = action.payload.open;
+                    break;
+                case 'rearPassengerDoor':
+                    state.doorStates.rearPassengerDoorOpen = action.payload.open;
+                    break;
+                case 'rearDriverDoor':
+                    state.doorStates.rearDriverDoorOpen = action.payload.open;
+                    break;
+                default:
+                    break;
+            }
         },
     },
 });
+
+export const { updateDoors } = slice.actions;
+
+export default slice.reducer;

--- a/src/features/Car/CarStore.tsx
+++ b/src/features/Car/CarStore.tsx
@@ -1,0 +1,73 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export enum DriveMode {
+    SPORT = 'Sport',
+    COMFORT = 'Comfort',
+    ECO = 'Eco',
+    RACE = 'race',
+}
+
+interface CarState {
+    doorStates: {
+        driverDoorOpen: boolean;
+        passengerDoorOpen: boolean;
+        rearDriverDoorOpen: boolean;
+        rearPassengerDoorOpen: boolean;
+        trunkOpen: boolean;
+    };
+
+    tirePressure: {
+        frontLeft: number;
+        frontRight: number;
+        backLeft: number;
+        backRight: number;
+    };
+
+    /* Note: battery level is one thing, however there is a question on how we should
+     *       store past battery level for the utilization graph. This question is mostly
+     *       how long should we store the percentage from. Should we store the last week
+     *       worth of data while updating the graph maybe once every minute? Should we maybe
+     *       store data from the last start? This would prob be the easiest to implement.
+     */
+    batteryLevel: Array<number>;
+    powerDraw: Array<number>;
+
+    driveMode: DriveMode;
+
+    // Used with current battery level to estimate range.
+    averagePowerDraw: number;
+
+    currentSpeed: number;
+}
+
+const initialState: CarState = {
+    doorStates: {
+        driverDoorOpen: false,
+        passengerDoorOpen: false,
+        rearDriverDoorOpen: false,
+        rearPassengerDoorOpen: false,
+        trunkOpen: false,
+    },
+    tirePressure: {
+        frontLeft: 0,
+        frontRight: 0,
+        backLeft: 0,
+        backRight: 0,
+    },
+    batteryLevel: [0],
+    powerDraw: [0],
+    driveMode: DriveMode.COMFORT,
+    averagePowerDraw: 0,
+    currentSpeed: 0,
+};
+
+export const slice = createSlice({
+    name: 'car',
+    initialState,
+    reducers: {
+        updateDoors: (state, action) => {
+            console.log(state);
+            console.log(action);
+        },
+    },
+});

--- a/src/features/Car/CarStore.tsx
+++ b/src/features/Car/CarStore.tsx
@@ -7,6 +7,22 @@ export enum DriveMode {
     RACE = 'race',
 }
 
+export enum DoorsEnum {
+    DRIVER = 'driverDoor',
+    PASSENGER = 'passengerDoor',
+    REARDRIVER = 'rearDriverDoor',
+    REARPASSENGER = 'rearPassengerDoor',
+    TRUNK = 'trunk',
+    FRUNK = 'frunk',
+}
+
+export enum TiresEnum {
+    FRONTLEFT = 'driverTire',
+    FRONTRIGHT = 'passengerTire',
+    BACKLEFT = 'rearDriverTire',
+    BACKRIGHT = 'rearPassengerTire',
+}
+
 interface CarState {
     doorStates: {
         driverDoorOpen: boolean;
@@ -14,6 +30,7 @@ interface CarState {
         rearDriverDoorOpen: boolean;
         rearPassengerDoorOpen: boolean;
         trunkOpen: boolean;
+        frunkOpen: boolean;
     };
 
     tirePressure: {
@@ -23,12 +40,6 @@ interface CarState {
         backRight: number;
     };
 
-    /* Note: battery level is one thing, however there is a question on how we should
-     *       store past battery level for the utilization graph. This question is mostly
-     *       how long should we store the percentage from. Should we store the last week
-     *       worth of data while updating the graph maybe once every minute? Should we maybe
-     *       store data from the last start? This would prob be the easiest to implement.
-     */
     batteryLevel: Array<number>;
     powerDraw: Array<number>;
 
@@ -47,6 +58,7 @@ const initialState: CarState = {
         rearDriverDoorOpen: false,
         rearPassengerDoorOpen: false,
         trunkOpen: false,
+        frunkOpen: false,
     },
     tirePressure: {
         frontLeft: 0,
@@ -65,6 +77,13 @@ export const slice = createSlice({
     name: 'car',
     initialState,
     reducers: {
+        /**
+         * Updates the state of a door in the store.
+         * @param state Current redux state.
+         * @param action The action to perform, this should have action.payload.door indicating the door to be changed (options are: 'driverDoor', 'passengerDoor',
+         *               'rearDriverDoor', 'rearPassengerDoor', 'trunk', 'frunk') but enums are also available for this. The second thing that should be passed in is the new door
+         *               state, action.payload.open should either be true or false.
+         */
         updateDoors: (state, action) => {
             switch (action.payload.door) {
                 case 'driverDoor':
@@ -78,6 +97,78 @@ export const slice = createSlice({
                     break;
                 case 'rearDriverDoor':
                     state.doorStates.rearDriverDoorOpen = action.payload.open;
+                    break;
+                case 'trunk':
+                    state.doorStates.trunkOpen = action.payload.open;
+                    break;
+                case 'frunk':
+                    state.doorStates.frunkOpen = action.payload.open;
+                    break;
+                default:
+                    break;
+            }
+        },
+
+        /**
+         * Updates store to reflect current battery percentage.
+         * @param state current redux state.
+         * @param action the action to perform, this should be action.payload.batteryLevel and should contain the current battery level.
+         */
+        updateBatteryLevel: (state, action) => {
+            // configered to record the last weeks worth of data every 30 mins.
+            if (state.batteryLevel.length >= 7 * 24 * 30) {
+                state.batteryLevel.shift();
+            }
+
+            state.batteryLevel.push(action.payload.batteryLevel);
+        },
+
+        /**
+         * Updates store to reflect current power draw.
+         * @param state current redux state.
+         * @param action the action to perform, this should be action.payload.powerDraw and should contain the current powerDraw.
+         */
+        updatePowerDraw: (state, action) => {
+            // configered to record the last weeks worth of data every 30 mins.
+            if (state.powerDraw.length >= 7 * 24 * 30) {
+                state.powerDraw.shift();
+            }
+
+            state.powerDraw.push(action.payload.powerDraw);
+
+            const sum = state.powerDraw.reduce((a, b) => a + b, 0);
+            state.averagePowerDraw = sum / state.powerDraw.length;
+        },
+
+        /**
+         * Updates the current speed in the store.
+         * @param state current redux state.
+         * @param action the action to perform, this should contain action.payload.speed and should be the speed the car is moving at.
+         */
+        updateCurrentSpeed: (state, action) => {
+            state.currentSpeed = action.payload.speed;
+        },
+
+        /**
+         * Updates the pressure of a tire in the store.
+         * @param state Current redux state.
+         * @param action The action to perform, this should have action.payload.tire indicating the tire to be changed (options are: 'drivertire', 'passengertire',
+         *               'rearDriverTire', 'rearPassengerTire') but enums are also available for this. The second thing that should be passed in is the new tire
+         *               pressure, action.payload.pressure should hold this.
+         */
+        updateTirePressure: (state, action) => {
+            switch (action.payload.tire) {
+                case 'driverTire':
+                    state.tirePressure.frontLeft = action.payload.pressure;
+                    break;
+                case 'passengerTire':
+                    state.tirePressure.frontRight = action.payload.pressure;
+                    break;
+                case 'rearPassengerTire':
+                    state.tirePressure.backRight = action.payload.pressure;
+                    break;
+                case 'rearDriverTire':
+                    state.tirePressure.backLeft = action.payload.pressure;
                     break;
                 default:
                     break;

--- a/src/pages/Car.tsx
+++ b/src/pages/Car.tsx
@@ -24,7 +24,7 @@ import { batteryHalfOutline, close } from 'ionicons/icons';
 import './Car.scss';
 import '../theme/Modal.scss';
 import './InnerModal.scss';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { setPage } from '../redux-features/Routing/RouterStore';
 import { Pages } from '../Models/Enums';
 import carAerial from '../assets/car-aerial/car-aerial-frame.svg';
@@ -34,6 +34,9 @@ import energyGraph from '../assets/graphs/Energy.jpg';
 import batteryGraph from '../assets/graphs/Battery.jpg';
 import Energy from './CarModals/Energy';
 import Battery from './CarModals/Battery';
+
+import { updateDoors } from '../features/Car/CarStore';
+import { doorStates, selectDarkModeActive } from '../app/reducersindex';
 
 const StyledIcon = styled(IonIcon).attrs((props: { colour: string }) => ({
     colour: props.colour,
@@ -55,9 +58,9 @@ const Car: React.FC = () => {
 
     const [showEnergy, setShowEnergy] = useState(false);
     const [showBattery, setShowBattery] = useState(false);
-    const [darkMode] = useState(document.body.classList.contains('dark'));
-    const [PassengerDoorOpen, setPassengerDoorOpen] = useState(false);
-    const [DriverDoorOpen, setDriverDoorOpen] = useState(false);
+    //const [darkMode] = useState(document.body.classList.contains('dark'));
+    const darkMode = useSelector(selectDarkModeActive);
+    const Doors = useSelector(doorStates);
 
     const openEnergyModal = function () {
         setShowEnergy(true);
@@ -65,24 +68,6 @@ const Car: React.FC = () => {
 
     const openBatteryModal = function () {
         setShowBattery(true);
-    };
-
-    //These functions are here to allow for easier implementation of IonToast notifications in the future
-
-    const openDriverDoor = function () {
-        setDriverDoorOpen(true);
-    };
-
-    const closeDriverDoor = function () {
-        setDriverDoorOpen(false);
-    };
-
-    const openPassengerDoor = function () {
-        setPassengerDoorOpen(true);
-    };
-
-    const closePassengerDoor = function () {
-        setPassengerDoorOpen(false);
     };
 
     return (
@@ -137,17 +122,31 @@ const Car: React.FC = () => {
                                 className="AerialViewDriverDoor"
                                 icon={driverDoor}
                                 colour={darkMode ? 'white' : 'black'}
-                                open={DriverDoorOpen ? 'rotate(32deg) translate(-37px)' : 'rotate(0deg) translate(0)'}
-                                onClick={DriverDoorOpen ? closeDriverDoor : openDriverDoor}
+                                open={
+                                    Doors.driverDoorOpen
+                                        ? 'rotate(32deg) translate(-37px)'
+                                        : 'rotate(0deg) translate(0)'
+                                }
+                                onClick={() =>
+                                    Doors.driverDoorOpen
+                                        ? dispatch(updateDoors({ door: 'driverDoor', open: false }))
+                                        : dispatch(updateDoors({ door: 'driverDoor', open: true }))
+                                }
                             />
                             <StyledDoor
                                 className="AerialViewPassengerDoor"
                                 icon={passengerDoor}
                                 colour={darkMode ? 'white' : 'black'}
                                 open={
-                                    PassengerDoorOpen ? 'rotate(-32deg) translate(37px)' : 'rotate(0deg) translate(0)'
+                                    Doors.passengerDoorOpen
+                                        ? 'rotate(-32deg) translate(37px)'
+                                        : 'rotate(0deg) translate(0)'
                                 }
-                                onClick={PassengerDoorOpen ? closePassengerDoor : openPassengerDoor}
+                                onClick={() =>
+                                    Doors.passengerDoorOpen
+                                        ? dispatch(updateDoors({ door: 'passengerDoor', open: false }))
+                                        : dispatch(updateDoors({ door: 'passengerDoor', open: true }))
+                                }
                             />
                         </IonCol>
                         {/* Modal to display the battery on click*/}

--- a/src/pages/Car.tsx
+++ b/src/pages/Car.tsx
@@ -37,6 +37,7 @@ import Battery from './CarModals/Battery';
 
 import { updateDoors } from '../features/Car/CarStore';
 import { doorStates, selectDarkModeActive } from '../app/reducersindex';
+import { DoorsEnum } from '../features/Car/CarStore';
 
 const StyledIcon = styled(IonIcon).attrs((props: { colour: string }) => ({
     colour: props.colour,
@@ -129,8 +130,8 @@ const Car: React.FC = () => {
                                 }
                                 onClick={() =>
                                     Doors.driverDoorOpen
-                                        ? dispatch(updateDoors({ door: 'driverDoor', open: false }))
-                                        : dispatch(updateDoors({ door: 'driverDoor', open: true }))
+                                        ? dispatch(updateDoors({ door: DoorsEnum.DRIVER, open: false }))
+                                        : dispatch(updateDoors({ door: DoorsEnum.DRIVER, open: true }))
                                 }
                             />
                             <StyledDoor
@@ -144,8 +145,8 @@ const Car: React.FC = () => {
                                 }
                                 onClick={() =>
                                     Doors.passengerDoorOpen
-                                        ? dispatch(updateDoors({ door: 'passengerDoor', open: false }))
-                                        : dispatch(updateDoors({ door: 'passengerDoor', open: true }))
+                                        ? dispatch(updateDoors({ door: DoorsEnum.PASSENGER, open: false }))
+                                        : dispatch(updateDoors({ door: DoorsEnum.PASSENGER, open: true }))
                                 }
                             />
                         </IonCol>


### PR DESCRIPTION
* See the bottom of document for inspiration 

# Additions
### Enums
These enums are designed to be used while interacting with the car reducers. This can help with specifing which tire or door the state should be updated for.

- Enums for the various doors on the car added, this includes: DoorsEnum.DRIVER, DoorsEnum.PASSENGER, DoorsEnum.REARDRIVER, DoorsEnum.REARPASSENGER, DoorsEnum.TRUNK, DoorsEnum.FRUNK
- Enums for each tire have been added, this includes: TiresEnum.FRONTLEFT, TiresEnum.FRONTRIGHT, TiresEnum.BACKLEFT, TiresEnum.BACKRIGHT

### Reducers
The following reducers have been added in CarStore.tsx:

- updateDoors, in its payload should be 'door' which is the door to update the state of, and 'open' which is true or false.
- updateBatteryLevel, in its payload should be 'batteryLevel' which is a number indicating current battery level.
- updatePowerDraw, in its payload should be 'powerDraw' which is a number indicating current power draw. This one is still up for debate on how we should do it but i can talk about it next meeting. 
- updateCurrentSpeed, its payload should be 'speed' indicating the current speed of the vehicle.
- updateTirePressure, its payload should be 'tire' indicating which tire to update, and 'pressure' indicating the tire pressure.

### Selectors
The following selectors have been added to the reducerIndex to be able to access the added states in the app:

- doorStates, this is an object with access to each doors 'open' state (true or false)
- tirePressure, this is an object with access to each tires pressure.
- batteryLevel, this is an array of past battery level, current battery level can be derived from accessing the last element of list.
- powerDraw, this is an array of past power draw, current power draw can be derived from accessing the last element of list.
- averagePowerDraw, this is the average power draw in the array of powerDraw.
- currentSpeed


> "The best error message is the one that never shows up." - Thomas Fuchs
![image](https://user-images.githubusercontent.com/70191282/152412497-00f7653b-92f5-4c30-afba-20cf6c742838.png)